### PR TITLE
Add support for neovim terminal buffers

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -204,6 +204,14 @@ hi link gitcommitUnmergedArrow gitcommitUnmergedFile
     let g:terminal_color_5 = s:purple.gui
     let g:terminal_color_6 = s:cyan.gui
     let g:terminal_color_7 = s:fg
+    let g:terminal_color_8 = s:bg
+    let g:terminal_color_9 = s:red.gui
+    let g:terminal_color_10 = s:green.gui
+    let g:terminal_color_11 = s:yellow.gui
+    let g:terminal_color_12 = s:blue.gui
+    let g:terminal_color_13 = s:purple.gui
+    let g:terminal_color_14 = s:cyan.gui
+    let g:terminal_color_15 = s:fg
     let g:terminal_color_background = g:terminal_color_0
     let g:terminal_color_foreground = g:terminal_color_7
   endif

--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -196,22 +196,14 @@ hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 
 " Fix colors in neovim terminal buffers {
   if has('nvim')
-    let g:terminal_color_0 = '#353a44'
-    let g:terminal_color_1 = '#e88388'
-    let g:terminal_color_2 = '#a7cc8c'
-    let g:terminal_color_3 = '#ebca8d'
-    let g:terminal_color_4 = '#72bef2'
-    let g:terminal_color_5 = '#d291e4'
-    let g:terminal_color_6 = '#65c2cd'
-    let g:terminal_color_7 = '#e3e5e9'
-    let g:terminal_color_8 = '#353a44'
-    let g:terminal_color_9 = '#e88388'
-    let g:terminal_color_10 = '#a7cc8c'
-    let g:terminal_color_11 = '#ebca8d'
-    let g:terminal_color_12 = '#72bef2'
-    let g:terminal_color_13 = '#d291e4'
-    let g:terminal_color_14 = '#65c2cd'
-    let g:terminal_color_15 = '#e3e5e9'
+    let g:terminal_color_0 = s:bg
+    let g:terminal_color_1 = s:red.gui
+    let g:terminal_color_2 = s:green.gui
+    let g:terminal_color_3 = s:yellow.gui
+    let g:terminal_color_4 = s:blue.gui
+    let g:terminal_color_5 = s:purple.gui
+    let g:terminal_color_6 = s:cyan.gui
+    let g:terminal_color_7 = s:fg
     let g:terminal_color_background = g:terminal_color_0
     let g:terminal_color_foreground = g:terminal_color_7
   endif

--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -193,3 +193,26 @@ hi link gitcommitDiscardedArrow gitcommitDiscardedFile
 hi link gitcommitSelectedArrow gitcommitSelectedFile
 hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 " }
+
+" Fix colors in neovim terminal buffers {
+  if has('nvim')
+    let g:terminal_color_0 = '#353a44'
+    let g:terminal_color_1 = '#e88388'
+    let g:terminal_color_2 = '#a7cc8c'
+    let g:terminal_color_3 = '#ebca8d'
+    let g:terminal_color_4 = '#72bef2'
+    let g:terminal_color_5 = '#d291e4'
+    let g:terminal_color_6 = '#65c2cd'
+    let g:terminal_color_7 = '#e3e5e9'
+    let g:terminal_color_8 = '#353a44'
+    let g:terminal_color_9 = '#e88388'
+    let g:terminal_color_10 = '#a7cc8c'
+    let g:terminal_color_11 = '#ebca8d'
+    let g:terminal_color_12 = '#72bef2'
+    let g:terminal_color_13 = '#d291e4'
+    let g:terminal_color_14 = '#65c2cd'
+    let g:terminal_color_15 = '#e3e5e9'
+    let g:terminal_color_background = g:terminal_color_0
+    let g:terminal_color_foreground = g:terminal_color_7
+  endif
+" }

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -204,6 +204,14 @@ hi link gitcommitUnmergedArrow gitcommitUnmergedFile
     let g:terminal_color_5 = s:purple.gui
     let g:terminal_color_6 = s:cyan.gui
     let g:terminal_color_7 = s:fg
+    let g:terminal_color_8 = s:bg
+    let g:terminal_color_9 = s:red.gui
+    let g:terminal_color_10 = s:green.gui
+    let g:terminal_color_11 = s:yellow.gui
+    let g:terminal_color_12 = s:blue.gui
+    let g:terminal_color_13 = s:purple.gui
+    let g:terminal_color_14 = s:cyan.gui
+    let g:terminal_color_15 = s:fg
     let g:terminal_color_background = g:terminal_color_0
     let g:terminal_color_foreground = g:terminal_color_7
   endif

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -193,3 +193,26 @@ hi link gitcommitDiscardedArrow gitcommitDiscardedFile
 hi link gitcommitSelectedArrow gitcommitSelectedFile
 hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 " }
+
+" Fix colors in neovim terminal buffers {
+  if has('nvim')
+    let g:terminal_color_0 = '#484b54'
+    let g:terminal_color_1 = '#eb6d5b'
+    let g:terminal_color_2 = '#60ae62'
+    let g:terminal_color_3 = '#cd9500'
+    let g:terminal_color_4 = '#0097c8'
+    let g:terminal_color_5 = '#b742b3'
+    let g:terminal_color_6 = '#00a7c0'
+    let g:terminal_color_7 = '#fbfbfb'
+    let g:terminal_color_8 = '#626571'
+    let g:terminal_color_9 = '#e88388'
+    let g:terminal_color_10 = '#a7cc8c'
+    let g:terminal_color_11 = '#ebca8d'
+    let g:terminal_color_12 = '#72bef2'
+    let g:terminal_color_13 = '#d291e4'
+    let g:terminal_color_14 = '#65c2cd'
+    let g:terminal_color_15 = '#ffffff'
+    let g:terminal_color_background = g:terminal_color_0
+    let g:terminal_color_foreground = g:terminal_color_7
+  endif
+" }

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -196,22 +196,14 @@ hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 
 " Fix colors in neovim terminal buffers {
   if has('nvim')
-    let g:terminal_color_0 = '#484b54'
-    let g:terminal_color_1 = '#eb6d5b'
-    let g:terminal_color_2 = '#60ae62'
-    let g:terminal_color_3 = '#cd9500'
-    let g:terminal_color_4 = '#0097c8'
-    let g:terminal_color_5 = '#b742b3'
-    let g:terminal_color_6 = '#00a7c0'
-    let g:terminal_color_7 = '#fbfbfb'
-    let g:terminal_color_8 = '#626571'
-    let g:terminal_color_9 = '#e88388'
-    let g:terminal_color_10 = '#a7cc8c'
-    let g:terminal_color_11 = '#ebca8d'
-    let g:terminal_color_12 = '#72bef2'
-    let g:terminal_color_13 = '#d291e4'
-    let g:terminal_color_14 = '#65c2cd'
-    let g:terminal_color_15 = '#ffffff'
+    let g:terminal_color_0 = s:bg
+    let g:terminal_color_1 = s:red.gui
+    let g:terminal_color_2 = s:green.gui
+    let g:terminal_color_3 = s:yellow.gui
+    let g:terminal_color_4 = s:blue.gui
+    let g:terminal_color_5 = s:purple.gui
+    let g:terminal_color_6 = s:cyan.gui
+    let g:terminal_color_7 = s:fg
     let g:terminal_color_background = g:terminal_color_0
     let g:terminal_color_foreground = g:terminal_color_7
   endif


### PR DESCRIPTION
Default onehalf theme looks distorted in terminal buffers when neovim true color mode is active.
Seeing as a increasing number of neovim plugins use the terminal buffer for REPL's etc, this can severely limit the appeal of this wonderful theme.

This PR remedies the issue described above by letting Neovim know what colors to use in the terminal buffer. by basically telling neovim what the hex colors of all 16 ansi colors are.