### PR TITLE
gnome-terminal: fix for no existing profiles and no uuidgen - fix for issue #28

### DIFF
--- a/gnome-terminal/onehalfdark.sh
+++ b/gnome-terminal/onehalfdark.sh
@@ -36,44 +36,43 @@ dlist_append() {
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
-
-    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
-        if which "$UUIDGEN" > /dev/null 2>&1; then
-            PROFILE_SLUG=`uuidgen`
-        fi
-
-        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
-            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
-        else
-            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
-        fi
-
-        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
-        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
-
-        # copy existing settings from default profile
-        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
-
-        # add new copy to list of profiles
-        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
-
-        # update profile values with theme options
-        dset visible-name "'$PROFILE_NAME'"
-        dset palette "['#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
-
-        dset background-color "'#282c34'"
-        dset foreground-color "'#dcdfe4'"
-        dset bold-color "'#dcdfe4'"
-        dset bold-color-same-as-fg "true"
-        dset use-theme-colors "false"
-        dset use-theme-background "false"
-
-        unset PROFILE_NAME
-        unset PROFILE_SLUG
-        unset DCONF
-        unset UUIDGEN
-        exit 0
+    if which "$UUIDGEN" > /dev/null 2>&1; then
+        PROFILE_SLUG=`uuidgen`
+    elif [ -f /proc/sys/kernel/random/uuid ]; then
+        PROFILE_SLUG=`cat /proc/sys/kernel/random/uuid`
     fi
+
+    if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+        DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+    else
+        DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+    fi
+
+    DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+    PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+    # copy existing settings from default profile
+    $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+    # add new copy to list of profiles
+    dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+    # update profile values with theme options
+    dset visible-name "'$PROFILE_NAME'"
+    dset palette "['#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
+
+    dset background-color "'#282c34'"
+    dset foreground-color "'#dcdfe4'"
+    dset bold-color "'#dcdfe4'"
+    dset bold-color-same-as-fg "true"
+    dset use-theme-colors "false"
+    dset use-theme-background "false"
+
+    unset PROFILE_NAME
+    unset PROFILE_SLUG
+    unset DCONF
+    unset UUIDGEN
+    exit 0
 fi
 
 # Fallback for Gnome 2 and early Gnome 3

--- a/gnome-terminal/onehalflight.sh
+++ b/gnome-terminal/onehalflight.sh
@@ -36,44 +36,43 @@ dlist_append() {
 # Newest versions of gnome-terminal use dconf
 if which "$DCONF" > /dev/null 2>&1; then
     [[ -z "$BASE_KEY_NEW" ]] && BASE_KEY_NEW=/org/gnome/terminal/legacy/profiles:
-
-    if [[ -n "`$DCONF list $BASE_KEY_NEW/`" ]]; then
-        if which "$UUIDGEN" > /dev/null 2>&1; then
-            PROFILE_SLUG=`uuidgen`
-        fi
-
-        if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
-            DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
-        else
-            DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
-        fi
-
-        DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
-        PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
-
-        # copy existing settings from default profile
-        $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
-
-        # add new copy to list of profiles
-        dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
-
-        # update profile values with theme options
-        dset visible-name "'$PROFILE_NAME'"
-        dset palette "['#383a42', '#e45649', '#50a14f', '#c18401', '#0184bc', '#a626a4', '#0997b3', '#fafafa', '#4f525e', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#ffffff']"
-
-        dset background-color "'#fafafa'"
-        dset foreground-color "'#383a42'"
-        dset bold-color "'#383a42'"
-        dset bold-color-same-as-fg "true"
-        dset use-theme-colors "false"
-        dset use-theme-background "false"
-
-        unset PROFILE_NAME
-        unset PROFILE_SLUG
-        unset DCONF
-        unset UUIDGEN
-        exit 0
+    if which "$UUIDGEN" > /dev/null 2>&1; then
+        PROFILE_SLUG=`uuidgen`
+    elif [ -f /proc/sys/kernel/random/uuid ]; then
+        PROFILE_SLUG=`cat /proc/sys/kernel/random/uuid`
     fi
+
+    if [[ -n "`$DCONF read $BASE_KEY_NEW/default`" ]]; then
+        DEFAULT_SLUG=`$DCONF read $BASE_KEY_NEW/default | tr -d \'`
+    else
+        DEFAULT_SLUG=`$DCONF list $BASE_KEY_NEW/ | grep '^:' | head -n1 | tr -d :/`
+    fi
+
+    DEFAULT_KEY="$BASE_KEY_NEW/:$DEFAULT_SLUG"
+    PROFILE_KEY="$BASE_KEY_NEW/:$PROFILE_SLUG"
+
+    # copy existing settings from default profile
+    $DCONF dump "$DEFAULT_KEY/" | $DCONF load "$PROFILE_KEY/"
+
+    # add new copy to list of profiles
+    dlist_append $BASE_KEY_NEW/list "$PROFILE_SLUG"
+
+    # update profile values with theme options
+    dset visible-name "'$PROFILE_NAME'"
+    dset palette "['#383a42', '#e45649', '#50a14f', '#c18401', '#0184bc', '#a626a4', '#0997b3', '#fafafa', '#4f525e', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#ffffff']"
+
+    dset background-color "'#fafafa'"
+    dset foreground-color "'#383a42'"
+    dset bold-color "'#383a42'"
+    dset bold-color-same-as-fg "true"
+    dset use-theme-colors "false"
+    dset use-theme-background "false"
+
+    unset PROFILE_NAME
+    unset PROFILE_SLUG
+    unset DCONF
+    unset UUIDGEN
+    exit 0
 fi
 
 # Fallback for Gnome 2 and early Gnome 3


### PR DESCRIPTION
- Removes check for existing profiles (profiles created from scratch if no existing profiles).
- Fall back to /proc/sys/kernel/random/uuid if uuidgen not installed.

Fixes https://github.com/sonph/onehalf/issues/28