### PR TITLE
Fix 'Installation & Usage' and 'License' links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,9 @@ A color scheme for Sublime Text, (Neo)Vim, iTerm, and more. Based on Atom's One.
 
 - [Features](#features)
 - [Screenshots](#screenshots)
-- [Installation & Usage](#installation-&-usage)
+- [Installation & Usage](#installation--usage)
 - [Contributing / Troubleshooting / Bug Reports](#contributing--troubleshooting--bug-reports)
-- [License](#license)
+- [License](LICENSE.txt)
 
 
 ## Features


### PR DESCRIPTION
This PR fix the follow errors:

* [FIX] The 'Installation & Usage' link on 'Table of Contents' is not working.
* [FIX] The 'License' link not exist. I redirect to LICENSE.txt file.

Great theme! Thanks to share :+1: 