### PR TITLE
lightline colors to match screenshots and airline colors

### DIFF
--- a/vim/autoload/lightline/colorscheme/onehalfdark.vim
+++ b/vim/autoload/lightline/colorscheme/onehalfdark.vim
@@ -2,7 +2,7 @@
 " Filename: autoload/lightline/colorscheme/onehalfdark.vim
 " Author: sonph
 " License: MIT License
-" Last Change: 2016/06/22
+" Last Change: 2019/12/01
 " =============================================================================
 
 let s:mono0 = [ '#282c34', 236 ]
@@ -20,8 +20,8 @@ let s:green = [ '#98c379', 114 ]
 let s:p = {'normal': {}, 'inactive': {}, 'insert': {}, 'replace': {}, 'visual': {}, 'tabline': {}}
 
 let s:p.normal.left = [ [ s:mono0, s:green ], [ s:mono3, s:mono2 ] ]
-let s:p.normal.middle = [ [ s:mono3, s:mono1 ] ]
-let s:p.normal.right = [ [ s:mono0, s:mono3 ], [ s:mono3, s:mono2 ] ]
+let s:p.normal.middle = [ [ s:green, s:mono1 ] ]
+let s:p.normal.right = [ [ s:mono0, s:green ], [ s:mono3, s:mono2 ] ]
 
 let s:p.normal.error = [ [ s:mono0, s:red ] ]
 let s:p.normal.warning = [ [ s:mono0, s:yellow ] ]
@@ -31,8 +31,16 @@ let s:p.inactive.middle = [ [ s:mono3, s:mono1 ] ]
 let s:p.inactive.right = [ [ s:mono0, s:mono3 ], [ s:mono3, s:mono2 ] ]
 
 let s:p.insert.left = [ [ s:mono0, s:blue ], [ s:mono3, s:mono2 ] ]
+let s:p.insert.middle = [ [ s:blue, s:mono1 ] ]
+let s:p.insert.right = [ [ s:mono0, s:blue ], [ s:mono3, s:mono2 ] ]
+
 let s:p.replace.left = [ [ s:mono0, s:red ], [ s:mono3, s:mono2 ] ]
+let s:p.replace.middle = [ [ s:red, s:mono1 ] ]
+let s:p.replace.right = [ [ s:mono0, s:red ], [ s:mono3, s:mono2 ] ]
+
 let s:p.visual.left = [ [ s:mono0, s:yellow ], [ s:mono3, s:mono2 ] ]
+let s:p.visual.middle = [ [ s:yellow, s:mono1 ] ]
+let s:p.visual.right = [ [ s:mono0, s:yellow ], [ s:mono3, s:mono2 ] ]
 
 let s:p.tabline.left = [ [ s:mono2, s:mono1] ]
 let s:p.tabline.tabsel = [ [ s:mono3, s:mono2 ] ]


### PR DESCRIPTION
Add mode colors to right of lightline status to be more similar to airline theme and screenshots.

Previously:
<img width="1486" alt="Screen Shot 2019-12-01 at 3 06 30 PM" src="https://user-images.githubusercontent.com/5923395/69922280-e11d7f00-144f-11ea-9a45-ee897a942c98.png">

Now:
<img width="1486" alt="Screen Shot 2019-12-01 at 3 32 20 PM" src="https://user-images.githubusercontent.com/5923395/69922281-e7abf680-144f-11ea-9b24-d4a1c876af65.png">