### PR TITLE
Update gitcommitSummary color

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -176,6 +176,7 @@ call s:h("diffRemoved", s:red, "", "")
 
 " Git {
 call s:h("gitcommitComment", s:comment_fg, "", "")
+call s:h("gitcommitSummary", s:blue, "", "")
 call s:h("gitcommitUnmerged", s:red, "", "")
 call s:h("gitcommitOnBranch", s:fg, "", "")
 call s:h("gitcommitBranch", s:purple, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -176,6 +176,7 @@ call s:h("diffRemoved", s:red, "", "")
 
 " Git {
 call s:h("gitcommitComment", s:comment_fg, "", "")
+call s:h("gitcommitSummary", s:blue, "", "")
 call s:h("gitcommitUnmerged", s:red, "", "")
 call s:h("gitcommitOnBranch", s:fg, "", "")
 call s:h("gitcommitBranch", s:purple, "", "")


### PR DESCRIPTION
This will update the `gitcommitSummary` color to blue.

The `gitcommitSummary` is defined as a Keyword:
https://github.com/vim/vim/blob/master/runtime/syntax/gitcommit.vim#L64

In the One Half theme, Keywords are set to be red. The problem with
red is when spellchecking is enabled, misspelled words are also set
to be red. (Yellow is also not a good choice because there are other
spelling-related issues that are set to be yellow.)

Let me know if blue is okay, or if you want me to change it to something else. :+1: :smiley: 