### PR TITLE
Add color theme to vim :terminal when termguicolors are set.

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -196,6 +196,19 @@ hi link gitcommitSelectedArrow gitcommitSelectedFile
 hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 " }
 
+" Fix colors in terminal buffers {
+  if has('terminal')
+    let g:terminal_ansi_colors = [
+          \ s:black.gui, s:red.gui, s:green.gui, s:yellow.gui,
+          \ s:blue.gui, s:purple.gui, s:cyan.gui, s:white.gui,
+          \ s:black.gui, s:red.gui, s:green.gui, s:yellow.gui,
+          \ s:blue.gui, s:purple.gui, s:cyan.gui, s:white.gui
+          \]
+    let g:terminal_color_background = s:bg.gui
+    let g:terminal_color_foreground = s:fg.gui
+  endif
+" }
+
 " Fix colors in neovim terminal buffers {
   if has('nvim')
     let g:terminal_color_0 = s:black.gui

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -196,6 +196,19 @@ hi link gitcommitSelectedArrow gitcommitSelectedFile
 hi link gitcommitUnmergedArrow gitcommitUnmergedFile
 " }
 
+" Fix colors in terminal buffers {
+  if has('terminal')
+    let g:terminal_ansi_colors = [
+          \ s:black.gui, s:red.gui, s:green.gui, s:yellow.gui,
+          \ s:blue.gui, s:purple.gui, s:cyan.gui, s:white.gui,
+          \ s:black.gui, s:red.gui, s:green.gui, s:yellow.gui,
+          \ s:blue.gui, s:purple.gui, s:cyan.gui, s:white.gui
+          \]
+    let g:terminal_color_background = s:bg.gui
+    let g:terminal_color_foreground = s:fg.gui
+  endif
+" }
+
 " Fix colors in neovim terminal buffers {
   if has('nvim')
     let g:terminal_color_0 = s:black.gui


### PR DESCRIPTION
[onehalfdark.vim] Add the terminal ansi colors to support :set termguicolors.

I noticed that the g:terminal_ansi_colors was not set which resulted in vim using the default 16 ANSI colors of the underlying terminal. This only occurs when termguicolors is set.

Not sure if this is the correct implementation but it worked for me afterwards.