### PR TITLE
Use gray for kitty color8

### DIFF
--- a/kitty/onehalf-dark.conf
+++ b/kitty/onehalf-dark.conf
@@ -10,7 +10,7 @@ url_color             #0087BD
 
 # black
 color0   #282c34
-color8   #282c36
+color8   #5d677a
 
 # red
 color1   #e06c75


### PR DESCRIPTION
For kitty, `color8` blends in with the background so that it's impossible to read. This is problematic in the example below with `mocha` test errors for Node.js:

<img width="825" alt="Screen Shot 2020-09-15 at 11 41 45 PM" src="https://user-images.githubusercontent.com/5923395/93301436-4e1abf00-f7ad-11ea-915e-c3e5b9e902ea.png">

I chose the [vim onehalf-dark mono2](https://github.com/sonph/onehalf/blob/f970a1277b37e587e73849c36d334ebb800766c7/vim/autoload/lightline/colorscheme/onehalfdark.vim#L10) color to make this legible. Here's the result with the same example:

<img width="893" alt="Screen Shot 2020-09-15 at 11 41 13 PM" src="https://user-images.githubusercontent.com/5923395/93301643-9934d200-f7ad-11ea-9a06-fc8dc0cf28ab.png">
