### PR TITLE
Introduce color for whitespace markers in Neovim.

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -119,6 +119,7 @@ call s:h("WildMenu", s:fg, "", "")
 
 
 " Syntax colors {
+call s:h("Whitespace", s:comment_fg, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")

--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -119,6 +119,8 @@ call s:h("WildMenu", s:fg, "", "")
 
 
 " Syntax colors {
+" Whitespace is defined in Neovim, not Vim.
+" See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:comment_fg, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -119,6 +119,7 @@ call s:h("WildMenu", s:fg, "", "")
 
 
 " Syntax colors {
+call s:h("Whitespace", s:comment_fg, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -119,6 +119,8 @@ call s:h("WildMenu", s:fg, "", "")
 
 
 " Syntax colors {
+" Whitespace is defined in Neovim, not Vim.
+" See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:comment_fg, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")


### PR DESCRIPTION
// This is a Neovim only feature, see  https://github.com/neovim/neovim/pull/6367.
// I tested it with Vim 8, as well where it simply has no effect.

When using

set list

In Vim, the whitespace characters would be drawn in the same color as
the text which is intrusive IMHO. This commit changes it to use the same
color as comments.

In order to make this compatible with regular Vim, one would probably
have to use `NonText`, instead.