### PR TITLE
Update cursor color in wal light colorscheme

### DIFF
--- a/wal/colorschemes/light/one-half-light.json
+++ b/wal/colorschemes/light/one-half-light.json
@@ -2,7 +2,7 @@
    "special":{
       "background": "#fafafa",
       "foreground": "#383a42",
-      "cursor":"#f0f0f0"
+      "cursor":"#bfceff"
    },
    "colors":{
     "color0": "#383a42",


### PR DESCRIPTION
This adapts the cursor color to match VSCode and other applications. Currently, the cursor color is very similar to the background, which makes editing longer commands a pain for the eyes.