### PR TITLE
Reduced contrast on non-text characters in VIM on both light &  dark

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -32,6 +32,7 @@ let s:bg          = s:black
 let s:comment_fg  = { "gui": "#5c6370", "cterm": "241" }
 let s:gutter_bg   = { "gui": "#282c34", "cterm": "236" }
 let s:gutter_fg   = { "gui": "#919baa", "cterm": "247" }
+let s:non_text    = { "gui": "#373C45", "cterm": "239" }
 
 let s:cursor_line = { "gui": "#313640", "cterm": "237" }
 let s:color_col   = { "gui": "#313640", "cterm": "237" }
@@ -61,7 +62,6 @@ endfun
 
 " User interface colors {
 call s:h("Normal", s:fg, s:bg, "")
-call s:h("NonText", s:fg, "", "")
 
 call s:h("Cursor", s:bg, s:blue, "")
 call s:h("CursorColumn", "", s:cursor_line, "")
@@ -121,7 +121,8 @@ call s:h("WildMenu", s:fg, "", "")
 " Syntax colors {
 " Whitespace is defined in Neovim, not Vim.
 " See :help hl-Whitespace and :help hl-SpecialKey
-call s:h("Whitespace", s:comment_fg, "", "")
+call s:h("Whitespace", s:non_text, "", "")
+call s:h("NonText", s:non_text, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -32,6 +32,7 @@ let s:bg          = s:white
 let s:comment_fg  = { "gui": "#a0a1a7", "cterm": "247" }
 let s:gutter_bg   = { "gui": "#fafafa", "cterm": "231" }
 let s:gutter_fg   = { "gui": "#d4d4d4", "cterm": "252" }
+let s:non_text    = { "gui": "#e5e5e5", "cterm": "252" }
 
 let s:cursor_line = { "gui": "#f0f0f0", "cterm": "255" }
 let s:color_col   = { "gui": "#f0f0f0", "cterm": "255" }
@@ -61,7 +62,6 @@ endfun
 
 " User interface colors {
 call s:h("Normal", s:fg, s:bg, "")
-call s:h("NonText", s:fg, "", "")
 
 call s:h("Cursor", s:bg, s:blue, "")
 call s:h("CursorColumn", "", s:cursor_line, "")
@@ -121,7 +121,8 @@ call s:h("WildMenu", s:fg, "", "")
 " Syntax colors {
 " Whitespace is defined in Neovim, not Vim.
 " See :help hl-Whitespace and :help hl-SpecialKey
-call s:h("Whitespace", s:comment_fg, "", "")
+call s:h("Whitespace", s:non_text, "", "")
+call s:h("NonText", s:non_text, "", "")
 call s:h("Comment", s:comment_fg, "", "")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")


### PR DESCRIPTION
This PR reduces the contrast between non-text and regular character colors

### Dark Half After Change
<img width="529" alt="Screen Shot 2020-10-14 at 5 13 33 PM" src="https://user-images.githubusercontent.com/4053376/96046054-df2e9580-0e40-11eb-903a-5a9f3bad47f9.png">

### Light Half Afer Change
<img width="518" alt="Screen Shot 2020-10-14 at 5 14 26 PM" src="https://user-images.githubusercontent.com/4053376/96046060-e2c21c80-0e40-11eb-9021-9532b9a2f67e.png">

