### PR TITLE
Italicize comments in Vim

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -123,7 +123,7 @@ call s:h("WildMenu", s:fg, "", "")
 " See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:non_text, "", "")
 call s:h("NonText", s:non_text, "", "")
-call s:h("Comment", s:comment_fg, "", "")
+call s:h("Comment", s:comment_fg, "", "italic")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")
 call s:h("Character", s:green, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -123,7 +123,7 @@ call s:h("WildMenu", s:fg, "", "")
 " See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:non_text, "", "")
 call s:h("NonText", s:non_text, "", "")
-call s:h("Comment", s:comment_fg, "", "")
+call s:h("Comment", s:comment_fg, "", "italic")
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")
 call s:h("Character", s:green, "", "")


### PR DESCRIPTION
Italicized comments are popular for Vim users and IMO they look pretty good. This won't have any effect on terminals that don't support italics.

![Screen Shot 2020-11-28 at 8 59 38 AM](https://user-images.githubusercontent.com/5923395/100521374-299d7480-3158-11eb-917c-6e1d8a19fdd2.png)