### PR TITLE
Fix inverted vim's popup menu for dark theme.

### DIFF
--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -84,7 +84,7 @@ call s:h("MoreMsg", s:fg, "", "")
 call s:h("WarningMsg", s:red, "", "")
 call s:h("Question", s:purple, "", "")
 
-call s:h("Pmenu", s:bg, s:fg, "")
+call s:h("Pmenu", s:fg, s:cursor_line, "")
 call s:h("PmenuSel", s:fg, s:blue, "")
 call s:h("PmenuSbar", "", s:selection, "")
 call s:h("PmenuThumb", "", s:fg, "")


### PR DESCRIPTION
Before: 
![Screenshot 2021-02-16 at 15 37 53](https://user-images.githubusercontent.com/12573521/108085570-613bfe80-706d-11eb-9159-4450af93c7ef.png)

After: 
![Screenshot 2021-02-16 at 15 40 01](https://user-images.githubusercontent.com/12573521/108085613-6b5dfd00-706d-11eb-8bb8-c709e41e6398.png)

Fix according to the light theme.

