### PR TITLE
g:onehalf_italic variable

### DIFF
--- a/vim/README.md
+++ b/vim/README.md
@@ -21,8 +21,9 @@ Download the files in [vim/](./) and put them in their respective folders
 ## Usage
 Put `colorscheme <scheme>` and `let g:airline_theme='<theme>'`, if using airline
 or `let g:lightline = { 'colorscheme': '<theme>' }`, if using lightline, in your `.vimrc`
-to set the color scheme and airline (or lightline) theme. Make sure you have
-syntax highlighting on, and 256 colors set. Vim version >= 7.4 recommended.
+to set the color scheme and airline (or lightline) theme. `let g:onehalf_italic = 1`
+before `colorscheme` to enable italics (requires terminal and font support). Make sure
+you have syntax highlighting on, and 256 colors set. Vim version >= 7.4 recommended.
 
 For example:
 
@@ -30,6 +31,7 @@ For example:
 syntax on
 set t_Co=256
 set cursorline
+let g:onehalf_italic = 1
 colorscheme onehalflight
 let g:airline_theme='onehalfdark'
 " lightline

--- a/vim/colors/onehalfdark.vim
+++ b/vim/colors/onehalfdark.vim
@@ -123,7 +123,11 @@ call s:h("WildMenu", s:fg, "", "")
 " See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:non_text, "", "")
 call s:h("NonText", s:non_text, "", "")
-call s:h("Comment", s:comment_fg, "", "italic")
+if exists("g:onehalf_italic") && g:onehalf_italic
+  call s:h("Comment", s:comment_fg, "", "italic")
+else
+  call s:h("Comment", s:comment_fg, "", "")
+endif
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")
 call s:h("Character", s:green, "", "")

--- a/vim/colors/onehalflight.vim
+++ b/vim/colors/onehalflight.vim
@@ -123,7 +123,11 @@ call s:h("WildMenu", s:fg, "", "")
 " See :help hl-Whitespace and :help hl-SpecialKey
 call s:h("Whitespace", s:non_text, "", "")
 call s:h("NonText", s:non_text, "", "")
-call s:h("Comment", s:comment_fg, "", "italic")
+if exists("g:onehalf_italic") && g:onehalf_italic
+  call s:h("Comment", s:comment_fg, "", "italic")
+else
+  call s:h("Comment", s:comment_fg, "", "")
+endif
 call s:h("Constant", s:cyan, "", "")
 call s:h("String", s:green, "", "")
 call s:h("Character", s:green, "", "")


### PR DESCRIPTION
Based on discussion in https://github.com/sonph/onehalf/pull/101, enabling italic comments by default is causing problems for enough users. Other color schemes solve this by using a variable to optionally enable italics.