### PR TITLE
Change alternative black color for xfce4-terminal

### DIFF
--- a/xfce4-terminal/OneHalfDark.theme
+++ b/xfce4-terminal/OneHalfDark.theme
@@ -55,4 +55,4 @@ ColorBold=#dcdfe4
 ColorBoldUseDefault=FALSE
 ColorCursor=#282C34
 #TabActivityColor=
-ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4
+ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#5d677a;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4


### PR DESCRIPTION
Change the alternative black color on the xfce4-terminal to `#5d677a` so it can
be contrasted against the background color. This color was obtained from the
[onehalfdark colormap for kitty](https://github.com/santisoler/onehalf/blob/master/kitty/onehalf-dark.conf).

This solves some issues on xfce4-terminal, like not being able to see the percentages in the bars of `htop`.

With `#282C34`:
![before](https://user-images.githubusercontent.com/11541317/113949192-0d37d580-97e5-11eb-8a99-9c86e96573f1.png)


With `#5d677a`:
![after](https://user-images.githubusercontent.com/11541317/113949194-0e690280-97e5-11eb-8ee4-2c163d60f2dc.png)
