### PR TITLE
Fix color for comments in shell

### DIFF
--- a/gnome-terminal/onehalfdark.sh
+++ b/gnome-terminal/onehalfdark.sh
@@ -59,7 +59,7 @@ if which "$DCONF" > /dev/null 2>&1; then
 
     # update profile values with theme options
     dset visible-name "'$PROFILE_NAME'"
-    dset palette "['#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
+    dset palette "['#5c6370', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
 
     dset background-color "'#282c34'"
     dset foreground-color "'#dcdfe4'"
@@ -109,7 +109,7 @@ glist_append() {
 glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
 
 gset string visible_name "$PROFILE_NAME"
-gset string palette "#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
+gset string palette "#5c6370:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
 gset string background_color "#282c34"
 gset string foreground_color "#dcdfe4"
 gset string bold_color "#dcdfe4"


### PR DESCRIPTION
This change makes comments in the shell the same color as defined
in the Vim colors. Before, commenting something out in the shell
would make it invisible because the same color was used as
for the background.