### PR TITLE
Fix the color of vscode status bar

### DIFF
--- a/vscode/onehalf-dark/themes/onehalf-dark-color-theme.json
+++ b/vscode/onehalf-dark/themes/onehalf-dark-color-theme.json
@@ -14,6 +14,8 @@
 		"sideBarSectionHeader.foreground": "#dcdfe4",
 		"statusBar.background": "#282c34",
 		"statusBar.foreground": "#dcdfe4",
+		"statusBar.noFolderBackground": "#282c34",
+		"statusBar.noFolderForeground": "#dcdfe4",
 		"panel.background": "#282c34"
 	},
 	"tokenColors": "./OneHalfDark.tmTheme",

--- a/vscode/onehalf-light/themes/onehalf-light-color-theme.json
+++ b/vscode/onehalf-light/themes/onehalf-light-color-theme.json
@@ -14,6 +14,8 @@
 		"sideBarSectionHeader.foreground": "#383a42",
 		"statusBar.background": "#fafafa",
 		"statusBar.foreground": "#383a42",
+		"statusBar.noFolderBackground": "#fafafa",
+		"statusBar.noFolderForeground": "#383a42",
 		"panel.background": "#fafafa"
 	},
 	"tokenColors": "./OneHalfLight.tmTheme",


### PR DESCRIPTION
When folders and workspaces were not open in VSCode, the default colors were displayed.
Fix to display the same colors as when the workspace is open.

fixes: https://github.com/sonph/onehalf/issues/115

Before changes
<img src=https://user-images.githubusercontent.com/5356309/142753531-2f3614bc-72f4-4e06-ab7c-b3b19737da6c.png width="518">
<img src=https://user-images.githubusercontent.com/5356309/142753537-2c5e0d78-4ec9-4c32-a039-28e64b2e0e60.png width="518">

After changes
<img src=https://user-images.githubusercontent.com/5356309/142753532-4204507e-0f34-4e97-8881-bc53ca9202ec.png width="518">
<img src=https://user-images.githubusercontent.com/5356309/142753543-f991c3cf-f27f-4f43-b831-1c056fccd393.png width="518">


