### PR TITLE
Fix bright black in OneHalf Dark

### DIFF
--- a/alacritty/README.md
+++ b/alacritty/README.md
@@ -63,7 +63,7 @@ colors:
     white: '0xdcdfe4'
 
   bright:
-    black: '0x282c34'
+    black: '0x5d677a'
     red: '0xe06c75'
     green: '0x98c379'
     yellow: '0xe5c07b'

--- a/fluentterminal/OneHalfDark.flutecolors
+++ b/fluentterminal/OneHalfDark.flutecolors
@@ -26,7 +26,7 @@
 		"Magenta": "#C678DD",
 		"Cyan": "#56B6C2",
 		"White": "#DCDFE4",
-		"BrightBlack": "#282C34",
+		"BrightBlack": "#5D677A",
 		"BrightRed": "#E06C75",
 		"BrightGreen": "#98C379",
 		"BrightYellow": "#E5C07B",

--- a/gnome-terminal/onehalfdark.sh
+++ b/gnome-terminal/onehalfdark.sh
@@ -59,7 +59,7 @@ if which "$DCONF" > /dev/null 2>&1; then
 
     # update profile values with theme options
     dset visible-name "'$PROFILE_NAME'"
-    dset palette "['#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
+    dset palette "['#282c34', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4', '#5d677a', '#e06c75', '#98c379', '#e5c07b', '#61afef', '#c678dd', '#56b6c2', '#dcdfe4']"
 
     dset background-color "'#282c34'"
     dset foreground-color "'#dcdfe4'"
@@ -109,7 +109,7 @@ glist_append() {
 glist_append string /apps/gnome-terminal/global/profile_list "$PROFILE_SLUG"
 
 gset string visible_name "$PROFILE_NAME"
-gset string palette "#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
+gset string palette "#282c34:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4:#5d677a:#e06c75:#98c379:#e5c07b:#61afef:#c678dd:#56b6c2:#dcdfe4"
 gset string background_color "#282c34"
 gset string foreground_color "#dcdfe4"
 gset string bold_color "#dcdfe4"

--- a/iterm/OneHalfDark.itermcolors
+++ b/iterm/OneHalfDark.itermcolors
@@ -199,13 +199,13 @@
 		<key>Alpha Component</key>
 		<real>1</real>
 		<key>Blue Component</key>
-		<real>0.203921568627</real>
+		<real>0.47843137383460999</real>
 		<key>Color Space</key>
 		<string>sRGB</string>
 		<key>Green Component</key>
-		<real>0.172549019608</real>
+		<real>0.40392157435417175</real>
 		<key>Red Component</key>
-		<real>0.156862745098</real>
+		<real>0.364705890417099</real>
 	</dict>
 	<key>Ansi 9 Color</key>
 	<dict>

--- a/konsole/onehalf-dark.colorscheme
+++ b/konsole/onehalf-dark.colorscheme
@@ -5,7 +5,7 @@ Color=40,44,52
 Color=40,44,52
 
 [Color0Intense]
-Color=40,44,52
+Color=93,103,122
 
 [Color1]
 Color=224,108,117

--- a/wal/colorschemes/dark/one-half-dark.json
+++ b/wal/colorschemes/dark/one-half-dark.json
@@ -13,7 +13,7 @@
     "color5": "#c678dd",
     "color6": "#56b6c2",
     "color7": "#dcdfe4",
-    "color8": "#282c34",
+    "color8": "#5d677a",
     "color9": "#e06c75",
     "color10": "#98c379",
     "color11": "#e5c07b",

--- a/windowsterminal/OneHalf.json
+++ b/windowsterminal/OneHalf.json
@@ -2,7 +2,7 @@
 	"background" : "#282C34",
 	"black" : "#282C34",
 	"blue" : "#61AFEF",
-	"brightBlack" : "#282C34",
+	"brightBlack" : "#5D677A",
 	"brightBlue" : "#61AFEF",
 	"brightCyan" : "#56B6C2",
 	"brightGreen" : "#98C379",

--- a/windowsterminal/OneHalfDark.json
+++ b/windowsterminal/OneHalfDark.json
@@ -2,7 +2,7 @@
     "background" : "#282C34",
     "black" : "#282C34",
     "blue" : "#61AFEF",
-    "brightBlack" : "#282C34",
+    "brightBlack" : "#5D677A",
     "brightBlue" : "#61AFEF",
     "brightCyan" : "#56B6C2",
     "brightGreen" : "#98C379",

--- a/xfce4-terminal/OneHalfDark.theme
+++ b/xfce4-terminal/OneHalfDark.theme
@@ -55,4 +55,4 @@ ColorBold=#dcdfe4
 ColorBoldUseDefault=FALSE
 ColorCursor=#282C34
 #TabActivityColor=
-ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4
+ColorPalette=#282c34;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4;#5d677a;#e06c75;#98c379;#e5c07b;#61afef;#c678dd;#56b6c2;#dcdfe4


### PR DESCRIPTION
Fixes #124 

I see that #92 changed color 8 to be different from the background, but this change was only applied to kitty. This PR will try and properly change it for all editors/terminals/etc supported.

Checklist:

- [x] alacritty
- [x] fluentterminal
- [x] gnome-terminal
- [x] iterm
- [x] ~~kitty~~ was done in #92
- [x] konsole
- [ ] mintty
- [ ] putty
- [x] ~~sublimetext~~ probably not needed (let me know if it does)
- [ ] terminal
- [x] ~~vim~~ not needed
- [x] ~~vscode~~ probably not needed (let me know if it does)
- [x] pywal
- [x] windowsterminal
- [ ] xcode
- [x] xfce4-terminal