### PR TITLE
WIP: Helix themes support

### DIFF
--- a/helix/README.md
+++ b/helix/README.md
@@ -1,0 +1,7 @@
+# Helix
+
+[Helix]() is self defined post modern modal editor, cross-platform, built in rust and with the idea of minimum configuration needed to start using as an complete code editor.
+
+Helix config files for themes are placed on `$XDG_CONFIG_HOME/helix/themes` where the themes files are TOML format files.
+
+Simply copy any of the variants you want from this repo, open helix editor and issue the `:theme` command, then search for "onehalf" and there's you go.

--- a/helix/README.md
+++ b/helix/README.md
@@ -1,7 +1,35 @@
 # Helix
 
-[Helix]() is self defined post modern modal editor, cross-platform, built in rust and with the idea of minimum configuration needed to start using as an complete code editor.
+[Helix](https://helix-editor.com/) is a post-modern modal editor, cross-platform, built in Rust with minimal configuration needed to start using as a complete code editor.
 
-Helix config files for themes are placed on `$XDG_CONFIG_HOME/helix/themes` where the themes files are TOML format files.
+## Installation
 
-Simply copy any of the variants you want from this repo, open helix editor and issue the `:theme` command, then search for "onehalf" and there's you go.
+Helix config files for themes are placed in `$XDG_CONFIG_HOME/helix/themes` (which typically expands to `~/.config/helix/themes` on Linux and macOS, or `%AppData%\helix\themes` on Windows).
+
+To install the OneHalf themes for Helix:
+
+1. Create the themes directory if it doesn't exist:
+   ```bash
+   mkdir -p ~/.config/helix/themes
+   ```
+
+2. Copy the theme files to the Helix themes directory:
+   ```bash
+   cp onehalf_dark.toml onehalf_light.toml ~/.config/helix/themes/
+   ```
+
+3. Open Helix editor and issue the `:theme` command
+   
+4. Search for "onehalf" and select either "onehalf_dark" or "onehalf_light"
+
+## Features
+
+- Complete syntax highlighting for many languages
+- Carefully selected colors matching the official OneHalf color scheme
+- Special styles for diagnostics, UI elements, and more
+- Proper styling for markup (Markdown, etc.)
+- Optimized for readability and reduced eye strain
+
+## Screenshots
+
+See the main repository README for screenshots of the OneHalf themes.

--- a/helix/onehalf_dark.toml
+++ b/helix/onehalf_dark.toml
@@ -1,0 +1,57 @@
+# Author : zoedsoupe (Zoey) <zoey.spessanha@zeetech.io>
+
+# Define the theme properties
+inherits = "default"
+
+# UI elements
+"ui.background" = { bg = "black" }
+"ui.text" = { fg = "white" }
+"ui.cursor" = { fg = "black", bg = "white" }
+"ui.cursorline" = { bg = "dark_gray" }
+"ui.selection" = { bg = "light_gray" }
+"ui.statusline" = { fg = "white", bg = "dark_gray" }
+"ui.statusline.inactive" = { fg = "light_gray", bg = "black" }
+"ui.gutter" = { fg = "light_gray", bg = "black" }
+"ui.linenr" = { fg = "light_gray", bg = "black" }
+"ui.linenr.selected" = { fg = "white", bg = "dark_gray" }
+"ui.popup" = { fg = "white", bg = "black" }
+
+# Syntax highlighting
+"comment" = { fg = "light_gray", modifiers = ["italic"] }
+"keyword" = { fg = "magenta" }
+"constant" = { fg = "cyan" }
+"string" = { fg = "green" }
+"function" = { fg = "blue" }
+"type" = { fg = "yellow" }
+"variable" = { fg = "red" }
+
+"attribute" = { fg = "cyan" }
+"operator" = { fg = "white" }
+"punctuation.delimiter" = { fg = "white" }
+"punctuation.bracket" = { fg = "white" }
+
+"builtin" = { fg = "magenta" }
+"parameter" = { fg = "red" }
+"boolean" = { fg = "cyan" }
+"numeric" = { fg = "yellow" }
+"escape" = { fg = "yellow" }
+"regexp" = { fg = "green" }
+
+# Diff highlighting
+"diff.plus" = { fg = "green", bg = "black" }
+"diff.minus" = { fg = "red", bg = "black" }
+"diff.delta" = { fg = "yellow", bg = "black" }
+"diff.moved" = { fg = "blue", bg = "black" }
+
+# Define the color palette
+[palette]
+black = "#282c34"
+red = "#e06c75"
+green = "#98c379"
+yellow = "#e5c07b"
+blue = "#61afef"
+magenta = "#c678dd"
+cyan = "#56b6c2"
+white = "#dcdfe4"
+light_gray = "#5c6370"
+dark_gray = "#3e4451"

--- a/helix/onehalf_dark.toml
+++ b/helix/onehalf_dark.toml
@@ -6,42 +6,113 @@ inherits = "default"
 # UI elements
 "ui.background" = { bg = "black" }
 "ui.text" = { fg = "white" }
-"ui.cursor" = { fg = "black", bg = "white" }
-"ui.cursorline" = { bg = "dark_gray" }
-"ui.selection" = { bg = "light_gray" }
-"ui.statusline" = { fg = "white", bg = "dark_gray" }
-"ui.statusline.inactive" = { fg = "light_gray", bg = "black" }
-"ui.gutter" = { fg = "light_gray", bg = "black" }
-"ui.linenr" = { fg = "light_gray", bg = "black" }
-"ui.linenr.selected" = { fg = "white", bg = "dark_gray" }
-"ui.popup" = { fg = "white", bg = "black" }
+"ui.cursor" = { fg = "black", bg = "blue" }
+"ui.cursor.primary" = { fg = "black", bg = "blue" }
+"ui.cursor.match" = { fg = "blue", modifiers = ["underlined"] }
+"ui.selection" = { bg = "selection" }
+"ui.selection.primary" = { bg = "selection" }
+"ui.cursorline.primary" = { bg = "cursor_line" }
+"ui.statusline" = { fg = "white", bg = "cursor_line" }
+"ui.statusline.inactive" = { fg = "light_gray", bg = "cursor_line" }
+"ui.statusline.normal" = { fg = "black", bg = "blue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "black", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "black", bg = "magenta", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "light_gray", bg = "cursor_line" }
+"ui.bufferline.active" = { fg = "cursor_line", bg = "blue" }
+"ui.linenr" = { fg = "gutter_fg", bg = "black" }
+"ui.linenr.selected" = { fg = "white", bg = "cursor_line" }
+"ui.popup" = { fg = "white", bg = "light_black" }
+"ui.window" = { fg = "cursor_line" }
+"ui.help" = { fg = "white", bg = "light_black" }
+"ui.virtual" = { fg = "light_gray" }
+"ui.virtual.ruler" = { bg = "cursor_line" }
+"ui.virtual.indent-guide" = { fg = "light_gray" }
+"ui.virtual.whitespace" = { fg = "light_gray" }
+"ui.virtual.inlay-hint" = { fg = "light_gray" }
+"ui.menu" = { fg = "white", bg = "light_black" }
+"ui.menu.selected" = { fg = "black", bg = "blue" }
+"ui.menu.scroll" = { fg = "white", bg = "light_black" }
+"ui.highlight" = { bg = "cursor_line" }
 
 # Syntax highlighting
 "comment" = { fg = "light_gray", modifiers = ["italic"] }
-"keyword" = { fg = "magenta" }
 "constant" = { fg = "cyan" }
+"constant.numeric" = { fg = "yellow" }
+"constant.character.escape" = { fg = "yellow" }
+"constant.builtin" = { fg = "yellow" }
+"constant.builtin.boolean" = { fg = "yellow" }
 "string" = { fg = "green" }
-"function" = { fg = "blue" }
-"type" = { fg = "yellow" }
-"variable" = { fg = "red" }
+"string.regexp" = { fg = "green" }
+"string.special" = { fg = "green" }
 
-"attribute" = { fg = "cyan" }
+"keyword" = { fg = "magenta" }
+"keyword.control" = { fg = "magenta" }
+"keyword.control.import" = { fg = "red" }
+"keyword.function" = { fg = "magenta" }
+"keyword.operator" = { fg = "magenta" }
+"keyword.directive" = { fg = "magenta" }
+"keyword.storage" = { fg = "magenta" }
+"keyword.storage.type" = { fg = "magenta" }
+"keyword.storage.modifier" = { fg = "magenta" }
+
 "operator" = { fg = "white" }
+"punctuation" = { fg = "white" }
 "punctuation.delimiter" = { fg = "white" }
 "punctuation.bracket" = { fg = "white" }
+"punctuation.special" = { fg = "white" }
 
-"builtin" = { fg = "magenta" }
-"parameter" = { fg = "red" }
-"boolean" = { fg = "cyan" }
-"numeric" = { fg = "yellow" }
-"escape" = { fg = "yellow" }
-"regexp" = { fg = "green" }
+"variable" = { fg = "red" }
+"variable.builtin" = { fg = "blue" }
+"variable.parameter" = { fg = "red" }
+"variable.other.member" = { fg = "red" }
 
-# Diff highlighting
+"type" = { fg = "yellow" }
+"type.builtin" = { fg = "yellow" }
+"type.enum.variant" = { fg = "yellow" }
+
+"constructor" = { fg = "blue" }
+"function" = { fg = "blue" }
+"function.builtin" = { fg = "blue" }
+"function.method" = { fg = "blue" }
+"function.macro" = { fg = "magenta" }
+"function.special" = { fg = "blue" }
+
+"tag" = { fg = "red" }
+"attribute" = { fg = "yellow" }
+"namespace" = { fg = "blue" }
+"special" = { fg = "blue" }
+"label" = { fg = "magenta" }
+
+# Markup
+"markup.heading" = { fg = "red" }
+"markup.bold" = { fg = "yellow", modifiers = ["bold"] }
+"markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }
+"markup.link.text" = { fg = "magenta" }
+"markup.raw" = { fg = "green" }
+"markup.quote" = { fg = "yellow" }
+"markup.list" = { fg = "red" }
+
+# Diagnostics
+"diagnostic" = { underline = { style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+"info" = { fg = "blue", modifiers = ["bold"] }
+"hint" = { fg = "green", modifiers = ["bold"] }
+"warning" = { fg = "yellow", modifiers = ["bold"] }
+"error" = { fg = "red", modifiers = ["bold"] }
+
+# Diff
 "diff.plus" = { fg = "green", bg = "black" }
 "diff.minus" = { fg = "red", bg = "black" }
 "diff.delta" = { fg = "yellow", bg = "black" }
-"diff.moved" = { fg = "blue", bg = "black" }
+"diff.delta.moved" = { fg = "blue", bg = "black" }
 
 # Define the color palette
 [palette]
@@ -54,4 +125,7 @@ magenta = "#c678dd"
 cyan = "#56b6c2"
 white = "#dcdfe4"
 light_gray = "#5c6370"
-dark_gray = "#3e4451"
+gutter_fg = "#919baa"
+cursor_line = "#313640"
+light_black = "#3e4451"
+selection = "#474e5d"

--- a/helix/onehalf_light.toml
+++ b/helix/onehalf_light.toml
@@ -6,42 +6,113 @@ inherits = "default"
 # UI elements
 "ui.background" = { bg = "white" }
 "ui.text" = { fg = "black" }
-"ui.cursor" = { fg = "white", bg = "black" }
-"ui.cursorline" = { bg = "light_gray" }
-"ui.selection" = { bg = "dark_gray" }
-"ui.statusline" = { fg = "black", bg = "light_gray" }
-"ui.statusline.inactive" = { fg = "dark_gray", bg = "white" }
-"ui.gutter" = { fg = "dark_gray", bg = "white" }
-"ui.linenr" = { fg = "dark_gray", bg = "white" }
-"ui.linenr.selected" = { fg = "black", bg = "light_gray" }
-"ui.popup" = { fg = "black", bg = "white" }
+"ui.cursor" = { fg = "white", bg = "blue" }
+"ui.cursor.primary" = { fg = "white", bg = "blue" }
+"ui.cursor.match" = { fg = "blue", modifiers = ["underlined"] }
+"ui.selection" = { bg = "selection" }
+"ui.selection.primary" = { bg = "selection" }
+"ui.cursorline.primary" = { bg = "cursor_line" }
+"ui.statusline" = { fg = "black", bg = "cursor_line" }
+"ui.statusline.inactive" = { fg = "dark_gray", bg = "cursor_line" }
+"ui.statusline.normal" = { fg = "white", bg = "blue", modifiers = ["bold"] }
+"ui.statusline.insert" = { fg = "white", bg = "green", modifiers = ["bold"] }
+"ui.statusline.select" = { fg = "white", bg = "magenta", modifiers = ["bold"] }
+"ui.bufferline" = { fg = "dark_gray", bg = "cursor_line" }
+"ui.bufferline.active" = { fg = "cursor_line", bg = "blue" }
+"ui.linenr" = { fg = "gutter_fg", bg = "white" }
+"ui.linenr.selected" = { fg = "black", bg = "cursor_line" }
+"ui.popup" = { fg = "black", bg = "light_gray" }
+"ui.window" = { fg = "cursor_line" }
+"ui.help" = { fg = "black", bg = "light_gray" }
+"ui.virtual" = { fg = "dark_gray" }
+"ui.virtual.ruler" = { bg = "cursor_line" }
+"ui.virtual.indent-guide" = { fg = "dark_gray" }
+"ui.virtual.whitespace" = { fg = "dark_gray" }
+"ui.virtual.inlay-hint" = { fg = "dark_gray" }
+"ui.menu" = { fg = "black", bg = "light_gray" }
+"ui.menu.selected" = { fg = "white", bg = "blue" }
+"ui.menu.scroll" = { fg = "black", bg = "light_gray" }
+"ui.highlight" = { bg = "cursor_line" }
 
 # Syntax highlighting
 "comment" = { fg = "dark_gray", modifiers = ["italic"] }
-"keyword" = { fg = "magenta" }
 "constant" = { fg = "cyan" }
+"constant.numeric" = { fg = "yellow" }
+"constant.character.escape" = { fg = "yellow" }
+"constant.builtin" = { fg = "yellow" }
+"constant.builtin.boolean" = { fg = "yellow" }
 "string" = { fg = "green" }
-"function" = { fg = "blue" }
-"type" = { fg = "yellow" }
-"variable" = { fg = "red" }
+"string.regexp" = { fg = "green" }
+"string.special" = { fg = "green" }
 
-"attribute" = { fg = "cyan" }
+"keyword" = { fg = "magenta" }
+"keyword.control" = { fg = "magenta" }
+"keyword.control.import" = { fg = "red" }
+"keyword.function" = { fg = "magenta" }
+"keyword.operator" = { fg = "magenta" }
+"keyword.directive" = { fg = "magenta" }
+"keyword.storage" = { fg = "magenta" }
+"keyword.storage.type" = { fg = "magenta" }
+"keyword.storage.modifier" = { fg = "magenta" }
+
 "operator" = { fg = "black" }
+"punctuation" = { fg = "black" }
 "punctuation.delimiter" = { fg = "black" }
 "punctuation.bracket" = { fg = "black" }
+"punctuation.special" = { fg = "black" }
 
-"builtin" = { fg = "magenta" }
-"parameter" = { fg = "red" }
-"boolean" = { fg = "cyan" }
-"numeric" = { fg = "yellow" }
-"escape" = { fg = "yellow" }
-"regexp" = { fg = "green" }
+"variable" = { fg = "red" }
+"variable.builtin" = { fg = "blue" }
+"variable.parameter" = { fg = "red" }
+"variable.other.member" = { fg = "red" }
 
-# Diff highlighting
+"type" = { fg = "yellow" }
+"type.builtin" = { fg = "yellow" }
+"type.enum.variant" = { fg = "yellow" }
+
+"constructor" = { fg = "blue" }
+"function" = { fg = "blue" }
+"function.builtin" = { fg = "blue" }
+"function.method" = { fg = "blue" }
+"function.macro" = { fg = "magenta" }
+"function.special" = { fg = "blue" }
+
+"tag" = { fg = "red" }
+"attribute" = { fg = "yellow" }
+"namespace" = { fg = "blue" }
+"special" = { fg = "blue" }
+"label" = { fg = "magenta" }
+
+# Markup
+"markup.heading" = { fg = "red" }
+"markup.bold" = { fg = "yellow", modifiers = ["bold"] }
+"markup.italic" = { fg = "magenta", modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link.url" = { fg = "cyan", modifiers = ["underlined"] }
+"markup.link.text" = { fg = "magenta" }
+"markup.raw" = { fg = "green" }
+"markup.quote" = { fg = "yellow" }
+"markup.list" = { fg = "red" }
+
+# Diagnostics
+"diagnostic" = { underline = { style = "curl" } }
+"diagnostic.info" = { underline = { color = "blue", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "green", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "yellow", style = "curl" } }
+"diagnostic.error" = { underline = { color = "red", style = "curl" } }
+"diagnostic.unnecessary" = { modifiers = ["dim"] }
+"diagnostic.deprecated" = { modifiers = ["crossed_out"] }
+
+"info" = { fg = "blue", modifiers = ["bold"] }
+"hint" = { fg = "green", modifiers = ["bold"] }
+"warning" = { fg = "yellow", modifiers = ["bold"] }
+"error" = { fg = "red", modifiers = ["bold"] }
+
+# Diff
 "diff.plus" = { fg = "green", bg = "white" }
 "diff.minus" = { fg = "red", bg = "white" }
 "diff.delta" = { fg = "yellow", bg = "white" }
-"diff.moved" = { fg = "blue", bg = "white" }
+"diff.delta.moved" = { fg = "blue", bg = "white" }
 
 # Define the color palette
 [palette]
@@ -53,5 +124,8 @@ blue = "#0184bc"
 magenta = "#a626a4"
 cyan = "#0997b3"
 white = "#fafafa"
-light_gray = "#d0d0d0"
 dark_gray = "#9a9a9a"
+gutter_fg = "#9a9a9a"
+cursor_line = "#f0f0f0"
+light_gray = "#e5e5e6"
+selection = "#d4d4d4"

--- a/helix/onehalf_light.toml
+++ b/helix/onehalf_light.toml
@@ -1,0 +1,57 @@
+# Author : zoedsoupe (Zoey) <zoey.spessanha@zeetech.io>
+
+# Define the theme properties
+inherits = "default"
+
+# UI elements
+"ui.background" = { bg = "white" }
+"ui.text" = { fg = "black" }
+"ui.cursor" = { fg = "white", bg = "black" }
+"ui.cursorline" = { bg = "light_gray" }
+"ui.selection" = { bg = "dark_gray" }
+"ui.statusline" = { fg = "black", bg = "light_gray" }
+"ui.statusline.inactive" = { fg = "dark_gray", bg = "white" }
+"ui.gutter" = { fg = "dark_gray", bg = "white" }
+"ui.linenr" = { fg = "dark_gray", bg = "white" }
+"ui.linenr.selected" = { fg = "black", bg = "light_gray" }
+"ui.popup" = { fg = "black", bg = "white" }
+
+# Syntax highlighting
+"comment" = { fg = "dark_gray", modifiers = ["italic"] }
+"keyword" = { fg = "magenta" }
+"constant" = { fg = "cyan" }
+"string" = { fg = "green" }
+"function" = { fg = "blue" }
+"type" = { fg = "yellow" }
+"variable" = { fg = "red" }
+
+"attribute" = { fg = "cyan" }
+"operator" = { fg = "black" }
+"punctuation.delimiter" = { fg = "black" }
+"punctuation.bracket" = { fg = "black" }
+
+"builtin" = { fg = "magenta" }
+"parameter" = { fg = "red" }
+"boolean" = { fg = "cyan" }
+"numeric" = { fg = "yellow" }
+"escape" = { fg = "yellow" }
+"regexp" = { fg = "green" }
+
+# Diff highlighting
+"diff.plus" = { fg = "green", bg = "white" }
+"diff.minus" = { fg = "red", bg = "white" }
+"diff.delta" = { fg = "yellow", bg = "white" }
+"diff.moved" = { fg = "blue", bg = "white" }
+
+# Define the color palette
+[palette]
+black = "#383a42"
+red = "#e45649"
+green = "#50a14f"
+yellow = "#c18401"
+blue = "#0184bc"
+magenta = "#a626a4"
+cyan = "#0997b3"
+white = "#fafafa"
+light_gray = "#d0d0d0"
+dark_gray = "#9a9a9a"


### PR DESCRIPTION
Following the #150, I tried to taclke the implementation of Helix editor themes for the light and dark variant for onehalf.

The Helix theme implementation documentation can be found [on their official docs](https://docs.helix-editor.com/themes.html).

Given that, the themes still need some visual tweaks, specially the light theme where some elements are invisible because of the white backgrounf color.

I just "imported" the default theme of Helix as a base theme to fill the missing gaps I can't determine which color of the pallete I should use.

So I would like to ask for help of official maintainers as I don't have somuch experience in implementing themes.

Here are some screenshots on tha code snippet written in `Elixir`:
<img width="946" alt="SCR-20240607-kruo-2" src="https://github.com/sonph/onehalf/assets/44469426/a1cf0dc4-2fe2-4612-b811-a3c42937fba1">

<img width="946" alt="SCR-20240607-ksai-2" src="https://github.com/sonph/onehalf/assets/44469426/82359b4d-1312-4c3a-bee4-a55dcc9c29d6">
