### PR TITLE
Fix name of OneHalfDark sublime theme

### DIFF
--- a/sublimetext/OneHalfDark.tmTheme
+++ b/sublimetext/OneHalfDark.tmTheme
@@ -28,7 +28,7 @@
 <plist version="1.0">
 <dict>
 	<key>name</key>
-	<string>OneHalfLight</string>
+	<string>OneHalfDark</string>
 	<key>semanticClass</key>
 	<string>theme.dark.one_half_dark</string>
 	<key>uuid</key>


### PR DESCRIPTION
I noticed that the name of `OneHalfDark` is actually `OneHalfLight`, that doesn't seem correct :)